### PR TITLE
Bump manifest version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "change getUserMedia and enumerateDevices results on the fly",
   "author": "Philipp Hancke",
   "version": "1.0.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "minimum_chrome_version": "34",
   "icons": {
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-getusermedia",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "change getUserMedia and enumerateDevices results on the fly",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The v2 reaches its EOL in a month, it already stopped working in Chrome Beta. Changing the version to `3` seems to work again.