### PR TITLE
Make content script compatible with Firefox and Chrome

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,49 +1,44 @@
-// This content script's primary role is now to tell the background script (or service worker in MV3)
-// to inject the main world script. However, since content scripts can use chrome.scripting.executeScript
-// directly if they have the "scripting" permission and matching host_permissions, we can do it here.
-
-// Ensure this runs only once or as needed
-if (typeof window.myExtensionInjected === "undefined") {
-    window.myExtensionInjected = true; // Simple flag to prevent multiple injections if content.js runs multiple times
-
-    if (window.chrome?.scripting) {
-        window.chrome.scripting
-            .executeScript({
-                target: {
-                    tabId: chrome.devtools.inspectedWindow.tabId,
-                    allFrames: true,
-                }, // Get tabId dynamically if not in devtools context
-                // If not in devtools, you'll need to get the tabId
-                // via messages from a background script or other means
-                // depending on when/how content.js is triggered.
-                // For typical content scripts, this isn't directly available.
-                // Let's assume this content script is for the main frame
-                // and you want to inject into the current tab.
-                // A more robust way to get current tabId might be needed
-                // if content.js isn't triggered by tab events directly.
-                // For simplicity, if this content.js is declared in manifest
-                // it will run in the context of a tab that matches.
-                // We often don't need to specify tabId if injecting into the
-                // tab the content script is running in.
-                // However, to be explicit for MAIN world:
-                func: () => {
-                    const script = document.createElement("script");
-                    script.src = chrome.runtime.getURL("injected_script.js");
-                    (document.head || document.documentElement).appendChild(
-                        script,
-                    );
-                    // The script will load and execute in the MAIN world.
-                    // You might want to remove it after execution if it's large and not needed.
-                    script.onload = () => script.remove();
-                },
-                injectImmediately: true, // Try to inject as soon as possible
-                world: "MAIN", // Execute in the main page context
-            })
-            .then(() => {
-                console.log("Injected main world script.");
-            })
-            .catch((err) => {
-                console.error("Failed to inject main world script:", err);
-            });
+// Helper function to get the extension's runtime API (chrome or browser)
+function getExtensionRuntime() {
+    if (typeof browser !== "undefined" && browser.runtime) {
+        return browser.runtime;
+    } else if (typeof chrome !== "undefined" && chrome.runtime) {
+        return chrome.runtime;
+    } else {
+        console.error("Dynamic GUM errors: Extension runtime API not found.");
+        return null;
     }
+}
+
+const runtimeAPI = getExtensionRuntime();
+
+if (runtimeAPI) {
+    const script = document.createElement("script");
+    script.src = runtimeAPI.getURL("injected_script.js");
+
+    // It's generally recommended to inject into document.documentElement
+    // as document.head might not be available when run_at is 'document_start'.
+    // insertBefore ensures it's one of the first scripts.
+    (document.head || document.documentElement).insertBefore(
+        script,
+        (document.head || document.documentElement).firstChild,
+    );
+
+    script.onload = function () {
+        // Optional: remove the script tag from the DOM after it has loaded
+        // This can help keep the DOM clean.
+        // However, be cautious if the injected script itself relies on being
+        // in the DOM for some reason (unlikely for this use case).
+        // script.parentNode.removeChild(script);
+        console.log("Dynamic GUM errors: Injected script loaded.");
+    };
+
+    script.onerror = function () {
+        console.error("Dynamic GUM errors: Failed to load injected_script.js.");
+    };
+} else {
+    // Fallback or error handling if no runtime API is found
+    console.error(
+        "Dynamic GUM errors: Could not determine extension runtime (Chrome or Firefox). Script injection failed.",
+    );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-getusermedia",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "description": "change getUserMedia and enumerateDevices results on the fly",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Refactors the content script to enable injection of the main world script (`injected_script.js`) in both Firefox and Chrome.

The script now dynamically checks for the `browser.runtime` (Firefox) or `chrome.runtime` (Chrome) API to correctly resolve the URL for the script to be injected. This replaces the Chrome-specific `chrome.scripting` API for this part of the injection, relying on standard DOM manipulation to add the script tag, which is cross-browser compatible.